### PR TITLE
fix(#22): optional properties not deleted

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -111,17 +111,28 @@ const handleRecord = (
 	const i = instruction.array
 	instruction.array++
 
-	return (
+	let v =
 		`(()=>{` +
 		`const ar${i}s=Object.keys(${property}),` +
 		`ar${i}v={};` +
 		`for(let i=0;i<ar${i}s.length;i++){` +
 		`const ar${i}p=${property}[ar${i}s[i]];` +
-		`ar${i}v[ar${i}s[i]]=${mirror(child, `ar${i}p`, instruction)}` +
-		`}` +
+		`ar${i}v[ar${i}s[i]]=${mirror(child, `ar${i}p`, instruction)}`;
+
+	const optionals = instruction.optionalsInArray[i + 1]
+	if (optionals) {
+		for (let oi = 0; oi < optionals.length; oi++) {
+			const target = `ar${i}v[ar${i}s[i]].${optionals[oi]}`
+
+			v += `;if(${target}===undefined)delete ${target}`
+		}
+	}
+
+	v += `}` +
 		`return ar${i}v` +
 		`})()`
-	)
+
+	return v
 }
 
 const handleTuple = (
@@ -334,6 +345,9 @@ const mirror = (
 				const key = keys[i]
 
 				let isOptional =
+					// all fields are optional
+					(!schema.required) ||
+					// field is explicitly required
 					(schema.required && !schema.required.includes(key)) ||
 					Array.isArray(schema.properties[key].anyOf)
 
@@ -468,9 +482,11 @@ const mirror = (
 
 	if (!isRoot) return v
 
-	if (schema.type === 'array') return `${v}return ar0v`
-
-	v = `const x=${v}\n`
+	if (schema.type === 'array') { // actually Tuple
+		v = `${v}const x=ar0v;`
+	} else {
+		v = `const x=${v}\n`
+	}
 
 	for (let i = 0; i < instruction.optionals.length; i++) {
 		const key = instruction.optionals[i]
@@ -480,7 +496,9 @@ const mirror = (
 
 		if (instruction.unionKeys[key]) v += `||x${prop}===undefined`
 
-		v += `)delete x${prop.charCodeAt(0) !== 63 ? '?' : ''}${prop}\n`
+		// 63 is '?'
+		const shouldQuestion = prop.charCodeAt(0) !== 63 && schema.type !== 'array'
+		v += `)delete x${shouldQuestion ? '?' : ''}${prop}\n`
 	}
 
 	return `${v}return x`

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1,6 +1,6 @@
 import { t } from 'elysia'
 
-import { describe, it, mock } from 'bun:test'
+import { describe, it } from 'bun:test'
 import { isEqual } from './utils'
 
 describe('Core', () => {

--- a/test/union.test.ts
+++ b/test/union.test.ts
@@ -2,7 +2,7 @@ import { t } from 'elysia'
 
 import { describe, it } from 'bun:test'
 
-import { isEqual, notEqual, isUndefined } from './utils'
+import { isEqual, notEqual } from './utils'
 
 describe('Union', () => {
 	it('handle union at root', () => {

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -1,5 +1,3 @@
-import { t } from 'elysia'
-
 import { Value } from '@sinclair/typebox/value'
 import { TypeCompiler } from '@sinclair/typebox/compiler'
 import { type TAnySchema } from '@sinclair/typebox'
@@ -17,7 +15,7 @@ export const isEqual = <T extends TAnySchema>(
 		createMirror(shape, {
 			TypeCompiler
 		})(value)
-	).toEqual(expected)
+	).toStrictEqual(expected)
 
 export const notEqual = <T extends TAnySchema>(
 	shape: T,
@@ -28,7 +26,7 @@ export const notEqual = <T extends TAnySchema>(
 		createMirror(shape, {
 			TypeCompiler
 		})(value)
-	).not.toEqual(expected)
+	).not.toStrictEqual(expected)
 
 export const isUndefined = <T extends TAnySchema>(
 	shape: T,
@@ -38,7 +36,7 @@ export const isUndefined = <T extends TAnySchema>(
 		createMirror(shape, {
 			TypeCompiler
 		})(value)
-	).toEqual(undefined)
+	).toStrictEqual(undefined)
 
 export const isEqualToTypeBox = <T extends TAnySchema>(
 	shape: T,
@@ -49,4 +47,4 @@ export const isEqualToTypeBox = <T extends TAnySchema>(
 		createMirror(shape, {
 			TypeCompiler
 		})(value)
-	).toEqual(Value.Clean(shape, value))
+	).toStrictEqual(Value.Clean(shape, value))


### PR DESCRIPTION
This PR fixes #22 and fixes elysiajs/elysia#1205
Previously, `.toEqual` was used to compare values in all tests, but it doesn't distinguish between undefined and non-existing properties leading to test passing with incorrect output. This PR replaces those `.toEqual` calls with `.toStrictEqual` that does make that distinction. With that change, 4 tests were failing:
```
Tuple > handle tuple object [1.60ms]
Sample > medium [4.21ms]
Sample > large [2.78ms]
Record > handle record object [0.67ms]
```
This PR fixes these 4 test cases by adding missing delete operations on tuples and records and accounting for objects where all properties are optional, in which case schema.required is undefined
Tuples handling seems a bit hacky to me at the end of `mirror()`, but I couldn't figure out how to handle them properly inside `handleTuple()`. All current tests pass tho, so that's good
I also removed some unused imports here and there if you don't mind
edit: typo