### PR TITLE
fix: resolve recursive reference nested inside a union branch (0.2.x)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.2.8 - Unreleased
+Bug fix:
+- [elysia#1823](https://github.com/elysiajs/elysia/issues/1823) dereference recursive reference nested in an union branch
+
 # 0.2.7 - 9 Feb 2025
 Bug fix:
 - [elysia#1700](https://github.com/elysiajs/elysia/issues/1700) distinct union object

--- a/src/index.ts
+++ b/src/index.ts
@@ -262,6 +262,40 @@ const handleUnion = (
 		return type
 	}
 
+	// resolve nested `This` so TypeBox can hoist `$id` when compiling a branch alone
+	const unwrapNestedRef = (type: TAnySchema): TAnySchema => {
+		if (!type || typeof type !== 'object') return type
+
+		if (
+			Kind in type &&
+			type[Kind] === 'This' &&
+			type.$ref in instruction.definitions
+		)
+			return instruction.definitions[type.$ref]
+
+		if (Array.isArray(type.anyOf))
+			return { ...type, anyOf: type.anyOf.map(unwrapNestedRef) }
+
+		if (type.properties) {
+			const properties = <Record<string, TAnySchema>>{}
+
+			for (const key of Object.keys(type.properties))
+				properties[key] = unwrapNestedRef(type.properties[key])
+
+			return { ...type, properties }
+		}
+
+		if (type.items)
+			return {
+				...type,
+				items: Array.isArray(type.items)
+					? type.items.map(unwrapNestedRef)
+					: unwrapNestedRef(type.items)
+			}
+
+		return type
+	}
+
 	// some type require cleaning before checking
 	// e.g. object with `additionalProperties: false`
 	let cleanThenCheck = ''
@@ -279,7 +313,7 @@ const handleUnion = (
 			else type.items = unwrapRef(type.items)
 		}
 
-		typeChecks.push(TypeCompiler.Compile(type))
+		typeChecks.push(TypeCompiler.Compile(unwrapNestedRef(type)))
 		v += `if(d.unions[${ui}][${i}].Check(${property})){return ${mirror(
 			type,
 			property,

--- a/test/recursive.test.ts
+++ b/test/recursive.test.ts
@@ -97,4 +97,99 @@ describe('Recursive', () => {
 
 		isEqual(shape, value)
 	})
+
+	it('handle reference nested in an object of an union branch', () => {
+		const shape = t.Recursive((This) =>
+			t.Object({
+				a: t.Union([t.Object({ another_a: This }), t.Literal('x')])
+			})
+		)
+
+		const value = {
+			a: {
+				another_a: {
+					a: {
+						another_a: {
+							a: 'x'
+						}
+					}
+				}
+			}
+		} satisfies typeof shape.static
+
+		isEqual(shape, value)
+
+		isEqual(
+			shape,
+			{
+				a: {
+					another_a: {
+						a: 'x',
+						unknown: 'b'
+					},
+					unknown: 'c'
+				},
+				unknown: 'd'
+			} as typeof shape.static,
+			{
+				a: {
+					another_a: {
+						a: 'x'
+					}
+				}
+			}
+		)
+	})
+
+	it('handle optional reference nested in an object of an union branch', () => {
+		const shape = t.Recursive((This) =>
+			t.Object({
+				a: t.Optional(
+					t.Union([t.Object({ another_a: This }), t.Literal('x')])
+				)
+			})
+		)
+
+		const value = {
+			a: {
+				another_a: {
+					a: {
+						another_a: {}
+					}
+				}
+			}
+		} satisfies typeof shape.static
+
+		isEqual(shape, value)
+		isEqual(shape, {})
+	})
+
+	it('handle reference in an array of an union branch', () => {
+		const shape = t.Recursive((This) =>
+			t.Object({
+				a: t.Union([
+					t.Array(t.Object({ another_a: This })),
+					t.Literal('x')
+				])
+			})
+		)
+
+		const value = {
+			a: [
+				{
+					another_a: {
+						a: [
+							{
+								another_a: {
+									a: 'x'
+								}
+							}
+						]
+					}
+				}
+			]
+		} satisfies typeof shape.static
+
+		isEqual(shape, value)
+	})
 })


### PR DESCRIPTION
fixes elysiajs/elysia#1823

backport for 0.2.x cuz thats what elysia pins (`^0.2.7`). branch is off `11799b2` (the 0.2.7 commit) not main, since main moved to typebox v1. opened as draft, cant merge into main as is, needs a cherry pick onto a 0.2 branch or just tag 0.2.8 from here, whatever u prefer

1.x version of this fix is #30

## whats broken

`t.Recursive` self ref nested inside an object prop of a union branch makes `createMirror` throw

```
TypeDereferenceError: Unable to dereference schema with $id 'T0'
```

`handleUnion` compiles each branch alone, `unwrapRef` only swaps a `This` thats the branch itself, so a nested one never gets resolved and theres no `$id` to hoist from. elysia catches it, logs "Failed to create exactMirror" and falls back to the slow cleaner

```ts
const A = t.Recursive((This) =>
	t.Object({ a: t.Union([t.Object({ another_a: This }), t.Literal('x')]) })
)
```

## fix

`unwrapNestedRef` walks a branchs `properties` / `items` / `anyOf` before compiling and swaps any `This` for its definition. definition carries `$id` so typebox hoists `check_T0` and deeper refs just work. shallow copies only, schema passed to `mirror()` is untouched so codegen is the same

fyi just passing `references` to `Compile` isnt enough, it only feeds `FromRef`, `FromThis` still emits `check_T0(value)` so compile passes then `.Check()` blows up with `check_T0 is not defined`. learned that the hard way

## tests

`test/recursive.test.ts` +3: nested in union (checks junk stripped at every level), under `Optional`, inside array. all threw before

`bun test` 65/65, node cjs+esm ok, build ok

## checked against elysia

dropped the built dist into elysia `node_modules`, full suite 1614/0 on bun 1.4, same as stock. issue repro returns 200 w/ junk stripped, no warning. startup like for like within noise, recursive routes ~30% more req/s cuz the mirror actually compiles now instead of falling back

## not covered

`This` under `patternProperties` / `allOf` / `additionalProperties` inside a branch still throws, same as before
