### PR TITLE
fix: resolve nested reference inside a union branch with definitions as context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 1.2.5 - Unreleased
+
+Bug fix:
+- a recursive `$ref` nested inside a union member (e.g. an object property of a union branch) is now dereferenced when compiling the branch check, instead of the value falling through unmirrored
+
 # 1.2.4 - 7 Aug 2026
 
 Bug fix:

--- a/src/index.ts
+++ b/src/index.ts
@@ -397,6 +397,30 @@ const withDefs = (type: AnySchema, group: CyclicGroup): AnySchema => {
 	) as AnySchema
 }
 
+// a branch subtree only needs the definitions context when it holds a `$ref`
+const hasRef = (schema: unknown, seen = new Set<object>()): boolean => {
+	if (schema === null || typeof schema !== 'object') return false
+	if (seen.has(schema)) return false
+	seen.add(schema)
+
+	if (Array.isArray(schema)) {
+		for (let i = 0; i < schema.length; i++)
+			if (hasRef(schema[i], seen)) return true
+
+		return false
+	}
+
+	for (const key in schema) {
+		const value = (<Record<string, unknown>>schema)[key]
+
+		if (key === '$ref' && typeof value === 'string') return true
+
+		if (hasRef(value, seen)) return true
+	}
+
+	return false
+}
+
 const handleUnion = (
 	schemas: AnySchema[],
 	property: string,
@@ -450,6 +474,13 @@ const handleUnion = (
 		return type
 	}
 
+	// context shadows `$defs`, cyclic defs must win
+	const context = instruction.cyclicDefs
+		? { ...instruction.definitions, ...instruction.cyclicDefs.defs }
+		: instruction.definitions
+
+	const hasDefinitions = Object.keys(context).length !== 0
+
 	// some type require cleaning before checking
 	// e.g. object with `additionalProperties: false`
 	let cleanThenCheck = ''
@@ -470,12 +501,15 @@ const handleUnion = (
 			type = copySchemaWith(type, { items })
 		}
 
+		const check = instruction.cyclicDefs
+			? (withDefs(type, instruction.cyclicDefs) as any)
+			: type
+
+		// nested `$ref` needs definitions as context
 		typeChecks.push(
-			instruction.Compile(
-				instruction.cyclicDefs
-					? (withDefs(type, instruction.cyclicDefs) as any)
-					: type
-			)
+			hasDefinitions && hasRef(type)
+				? instruction.Compile(context as any, check)
+				: instruction.Compile(check)
 		)
 		v += `if(d.unions[${ui}][${i}].Check(${property})){return ${mirror(
 			type,

--- a/test/cyclic.test.ts
+++ b/test/cyclic.test.ts
@@ -335,4 +335,75 @@ describe('Cyclic', () => {
 			}
 		})
 	})
+
+	it('resolve cyclic $defs over a same-named definition', () => {
+		// TypeBox resolves a `$ref` from the compile context before the
+		// schema's own `$defs`, so a definition sharing a name with a cyclic
+		// one must not shadow it when compiling a union branch
+		const shape = t.Cyclic(
+			{
+				a: t.Object({
+					type: t.String(),
+					data: t.Union([
+						t.Object({ another: t.Ref('a') }),
+						t.Null()
+					])
+				})
+			},
+			'a'
+		)
+
+		const mirror = createMirror(shape, {
+			Compile,
+			definitions: { a: t.Object({ unrelated: t.Number() }) }
+		})
+
+		expect(
+			mirror({
+				type: 'yea',
+				extra: 'x',
+				data: {
+					extra: 'x',
+					another: {
+						type: 'ok',
+						extra: 'x',
+						data: null
+					}
+				}
+			} as any)
+		).toEqual({
+			type: 'yea',
+			data: {
+				another: {
+					type: 'ok',
+					data: null
+				}
+			}
+		})
+	})
+
+	it('resolve a direct cyclic ref union member over a same-named definition', () => {
+		const mirror = createMirror(node, {
+			Compile,
+			definitions: { a: t.Object({ unrelated: t.Number() }) }
+		})
+
+		expect(
+			mirror({
+				type: 'yea',
+				extra: 'x',
+				data: {
+					type: 'ok',
+					extra: 'x',
+					data: null
+				}
+			} as any)
+		).toEqual({
+			type: 'yea',
+			data: {
+				type: 'ok',
+				data: null
+			}
+		})
+	})
 })

--- a/test/ref.test.ts
+++ b/test/ref.test.ts
@@ -206,4 +206,184 @@ describe('Ref', () => {
 			}
 		})
 	})
+
+	it('handle recursion nested in an object inside union branch', () => {
+		const definitions = {
+			a: t.Object({
+				type: t.String(),
+				data: t.Union([t.Object({ another: t.Ref('a') }), t.Null()])
+			})
+		}
+
+		const mirror = createMirror(definitions.a, {
+			Compile,
+			definitions
+		})
+
+		// the branch is only selected if its nested `$ref` is dereferenced,
+		// otherwise the value falls through unmirrored
+		expect(
+			mirror({
+				type: 'yea',
+				extra: 'x',
+				data: {
+					extra: 'x',
+					another: {
+						type: 'ok',
+						extra: 'x',
+						data: null
+					}
+				}
+			} as any)
+		).toEqual({
+			type: 'yea',
+			data: {
+				another: {
+					type: 'ok',
+					data: null
+				}
+			}
+		})
+	})
+
+	it('handle recursion nested 3 levels deep inside union branch', () => {
+		const definitions = {
+			a: t.Object({
+				type: t.String(),
+				data: t.Union([
+					t.Object({ l1: t.Object({ l2: t.Ref('a') }) }),
+					t.Null()
+				])
+			})
+		}
+
+		const mirror = createMirror(definitions.a, {
+			Compile,
+			definitions
+		})
+
+		expect(
+			mirror({
+				type: 'yea',
+				extra: 'x',
+				data: {
+					extra: 'x',
+					l1: {
+						extra: 'x',
+						l2: {
+							type: 'ok',
+							extra: 'x',
+							data: null
+						}
+					}
+				}
+			} as any)
+		).toEqual({
+			type: 'yea',
+			data: {
+				l1: {
+					l2: {
+						type: 'ok',
+						data: null
+					}
+				}
+			}
+		})
+	})
+
+	it('handle optional recursion inside union branch', () => {
+		const definitions = {
+			a: t.Object({
+				type: t.String(),
+				data: t.Union([
+					t.Object({ opt: t.Optional(t.Ref('a')) }),
+					t.Null()
+				])
+			})
+		}
+
+		const mirror = createMirror(definitions.a, {
+			Compile,
+			definitions
+		})
+
+		expect(
+			mirror({
+				type: 'yea',
+				extra: 'x',
+				data: {
+					extra: 'x',
+					opt: {
+						type: 'ok',
+						extra: 'x',
+						data: null
+					}
+				}
+			} as any)
+		).toEqual({
+			type: 'yea',
+			data: {
+				opt: {
+					type: 'ok',
+					data: null
+				}
+			}
+		})
+
+		expect(
+			mirror({
+				type: 'yea',
+				data: {
+					extra: 'x'
+				}
+			} as any)
+		).toEqual({
+			type: 'yea',
+			data: {}
+		})
+	})
+
+	it('handle recursion in an array of object inside union branch', () => {
+		const definitions = {
+			a: t.Object({
+				type: t.String(),
+				data: t.Union([
+					t.Array(t.Object({ child: t.Ref('a') })),
+					t.Null()
+				])
+			})
+		}
+
+		const mirror = createMirror(definitions.a, {
+			Compile,
+			definitions
+		})
+
+		expect(
+			mirror({
+				type: 'yea',
+				extra: 'x',
+				data: [
+					{
+						extra: 'x',
+						child: {
+							type: 'ok',
+							extra: 'x',
+							data: null
+						}
+					}
+				]
+			} as any)
+		).toEqual({
+			type: 'yea',
+			data: [
+				{
+					child: {
+						type: 'ok',
+						data: null
+					}
+				}
+			]
+		})
+	})
 })


### PR DESCRIPTION
fixes elysiajs/elysia#1823

## whats broken

`handleUnion` compiles every `anyOf` branch on its own, so if a `$ref` is buried inside the branch (object prop, array item, nested union) the compiled check cant resolve it. `unwrapRef` only handles the case where the ref *is* the branch.

on typebox v1 this fails silently, branch check just returns false, nothing matches and the value falls thru the mirror unstripped, so unknown keys leak. not great cuz thats literally the one thing this lib is for lol

```ts
const A = t.Recursive((This) =>
	t.Object({ a: t.Union([t.Object({ another_a: This }), t.Literal('x')]) })
)
```

## fix

pass `instruction.definitions` as compile context (`Compile(context, type)`) so nested refs resolve at `.Check()` time. ez in theory but 2 gotchas came up:

- typebox looks up the context *before* the schemas own `$defs`, so a cyclic def would get shadowed by a same named definition. context is now `{ ...definitions, ...cyclicDefs.defs }` so cyclic wins
- `Compile(context, type)` walks every context key per branch (`HasUnevaluated`), build time scaled with number of definitions (17x at 200 defs). added a tiny `hasRef` walker so branches w/o any `$ref` compile exactly like before. no-ref branches r flat again

runtime cost unchanged, all this happens once at mirror creation

## tests

- `test/ref.test.ts` +4: ref nested in object inside union, 3 deep, under `Optional`, inside array. all red before green after
- `test/cyclic.test.ts` +2: cyclic defs win over same named definition

`bun test` 162/162, node cjs+esm ok, build ok

## note

elysia still pins `^0.2.7` so this alone doesnt close the issue, theres a companion pr for the 0.2 line, #29


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed recursive schema references nested within union branches, including nested objects, optional fields, and arrays.
  - Improved handling of cyclic schema definitions during validation and compilation.
  - Unknown properties are now consistently removed throughout recursively referenced structures, including cases where definitions share names.

- **Tests**
  - Added coverage for nested, multi-level, optional, array-based, and cyclic reference scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->