### PR TITLE
fix: return a non-array value as-is instead of dereferencing .length (0.2.x)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.2.8 - Unreleased
+Bug fix:
+- return a non-array value as-is instead of dereferencing `.length`, e.g. an array in a union branch cleaned against a value of another branch
+
 # 0.2.7 - 9 Feb 2025
 Bug fix:
 - [elysia#1700](https://github.com/elysiajs/elysia/issues/1700) distinct union object

--- a/src/index.ts
+++ b/src/index.ts
@@ -470,11 +470,17 @@ const mirror = (
 
 			let reference = property
 
-			if (isRoot) v = `const ar${i}v=new Array(${property}.length);`
+			// the value may not be an array, e.g. a union branch mirrored by
+			// `cleanThenCheck` against a value belonging to another branch
+			if (isRoot)
+				v =
+					`if(!Array.isArray(${property}))return ${property};` +
+					`const ar${i}v=new Array(${property}.length);`
 			else {
 				reference = `ar${i}s`
 				v =
 					`((${reference})=>{` +
+					`if(!Array.isArray(${reference}))return ${reference};` +
 					`const ar${i}v=new Array(${reference}.length);`
 			}
 

--- a/test/union-array-branch.test.ts
+++ b/test/union-array-branch.test.ts
@@ -1,0 +1,104 @@
+import { t } from 'elysia'
+
+import { describe, it } from 'bun:test'
+
+import { isEqual, isEqualToTypeBox } from './utils'
+
+// An array inside a union branch is mirrored against the raw value by the
+// `cleanThenCheck` pass, which runs EVERY branch's mirror expression - so the
+// array wrapper receives values that belong to another branch, or no branch.
+describe('Union with an array branch', () => {
+	const strictNode = t.Union([
+		t.Object(
+			{
+				type: t.Literal('AND'),
+				children: t.Array(t.Object({ type: t.String() }))
+			},
+			{ additionalProperties: false }
+		),
+		t.Object(
+			{
+				type: t.Literal('leaf'),
+				param: t.String()
+			},
+			{ additionalProperties: false }
+		)
+	])
+
+	it('clean then check a branch without the array property', () => {
+		const shape = t.Object({ tree: strictNode })
+
+		isEqual(
+			shape,
+			{
+				tree: {
+					type: 'leaf',
+					param: 'p',
+					// @ts-ignore
+					junk: 1
+				}
+			},
+			{
+				tree: {
+					type: 'leaf',
+					param: 'p'
+				}
+			}
+		)
+	})
+
+	it('return a value matching no branch as-is', () => {
+		const shape = t.Object({ tree: strictNode })
+
+		isEqual(
+			shape,
+			// @ts-ignore
+			{ tree: { type: 'AND' } }
+		)
+	})
+
+	it('return null in an array-bearing union as-is', () => {
+		const shape = t.Object({ tree: strictNode })
+
+		isEqual(
+			shape,
+			// @ts-ignore
+			{ tree: null }
+		)
+	})
+
+	it('handle null on a root union with an array branch', () => {
+		const shape = t.Union([
+			t.Array(t.Object({ a: t.String() })),
+			t.Object({ b: t.String() })
+		])
+
+		isEqual(
+			shape,
+			// @ts-ignore
+			null
+		)
+	})
+
+	it('handle a non-array on an array root', () => {
+		const shape = t.Array(t.Object({ a: t.String() }))
+
+		isEqualToTypeBox(
+			shape,
+			// @ts-ignore
+			null
+		)
+	})
+
+	it('return a non-array at an optional array property as-is, no union', () => {
+		const shape = t.Object({
+			x: t.Optional(t.Array(t.Object({ a: t.String() })))
+		})
+
+		isEqual(
+			shape,
+			// @ts-ignore
+			{ x: null }
+		)
+	})
+})


### PR DESCRIPTION
## whats broken

The generated array wrapper dereferences `.length` on a value that is not an array:

```
TypeError: undefined is not an object (evaluating 'ar0s.length')
```

It is reached from `handleUnion`'s `cleanThenCheck` pass, which runs EVERY branch's mirror expression against the raw value. A branch containing an array, mirrored against a value that belongs to another branch (or to none, or `null`), hits `new Array(x.length)` with `x === undefined`.

The by-design case — the pass exists for `additionalProperties: false` objects, and this is that case:

```ts
const node = Type.Union([
	Type.Object({ type: Type.Literal('AND'), children: Type.Array(Type.Object({ type: Type.String() })) }, { additionalProperties: false }),
	Type.Object({ type: Type.Literal('leaf'), param: Type.String() }, { additionalProperties: false })
])

createMirror(Type.Object({ tree: node }), { TypeCompiler })({ tree: { type: 'leaf', param: 'p', junk: 1 } })
// throws — expected { tree: { type: 'leaf', param: 'p' } }
```

Without `junk` the leaf branch `Check`s raw and nothing throws. With it, both raw checks fail, `cleanThenCheck` mirrors the `AND` branch first, and the wrapper receives `v.tree?.children` = `undefined`.

Same throw for a value matching no branch (`{ tree: { type: 'AND' } }`), for `{ tree: null }`, for `null` on a root union with an array branch, and — one more site, same line — `createMirror(Type.Array(...))(null)` throws `v.length` where `Value.Clean` returns `null`.

Through Elysia (1.4.22, `app.handle`, body `t.Object({ tree: node })`): the leaf-with-one-extra-key body comes back **422 "Expected union value"** instead of 200 with the key stripped, and a response schema of the same shape 422s the handler's own return value.

## fix

Emit `if(!Array.isArray(x))return x;` before `new Array(x.length)` at both sites (root and the IIFE). A non-array at an array position is returned as-is, which is what `Value.Clean` does and what `handleUnion` already does for a value matching no branch. Values that are arrays produce byte-identical code apart from the guard.

Always emitted rather than predicated on `fromUnion`: the root site has no union context by construction, and the `Type.Array(...)(null)` case has no union at all. mitata `array` / `medium` / `large` before and after are within run-to-run noise (12.5 / 33 / 200 ns per iter, 3 runs each).

## tests

`test/union-array-branch.test.ts` +6: the strict-union case above, no-branch value, `null` in the union, `null` on a root union with an array branch, `null` at a `t.Optional(t.Array(...))` property with no union at all, `null` on an array root (against `Value.Clean`). All threw before.

`bun test` 68/68, node cjs+esm ok, build ok.

## not covered

A tuple given a non-array still throws (`v[0]`), different site (`handleTuple`). With `sanitize`, a non-array at an array position now passes through unsanitized where it used to throw inside the sanitizer; real arrays sanitize as before.

Same code on `main` — the diff applies there without fuzz; happy to open the 1.x twin like #29/#30 if you want it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed array validation so non-array values are preserved unchanged instead of being processed as arrays.
  - Improved handling of union types, including `null`, missing or unknown branches, and optional array properties.
  - Valid union values continue to have unknown properties removed correctly.

- **Tests**
  - Added coverage for array and union validation edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->